### PR TITLE
Add basic logging functionalities to the module

### DIFF
--- a/tests/test_queryer.py
+++ b/tests/test_queryer.py
@@ -1,4 +1,9 @@
+import logging
 import queryer
+
+
+logging.root.setLevel(logging.DEBUG)
+
 
 query = {
     'composition': 'Ni:1:1',


### PR DESCRIPTION
This PR converts blanket `print` statements into logs using the `logging` library. Options are provided for the user to specify `nolog`, `console`, or a file stream, as required.